### PR TITLE
Add Vietnamese support to DejaVu Sans Code

### DIFF
--- a/src/DejaVuSansCode-Bold.sfd
+++ b/src/DejaVuSansCode-Bold.sfd
@@ -18,7 +18,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: 1470648507
-ModificationTime: 1505816978
+ModificationTime: 1557141162
 PfmFamily: 17
 TTFWeight: 700
 TTFWidth: 5
@@ -65,78 +65,78 @@ MarkAttachClasses: 1
 DEI: 91125
 ChainSub2: glyph "'calt' Programming contextual alternatives lookup 1"  0 0 0 15
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 5 equal
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 16 equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 22 equal_equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 4 plus
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 14 plus_plus.liga
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 14 plus_plus.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 4 plus
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 18 greater_equal.liga
  BString: 7 greater
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 15 less_equal.liga
  BString: 4 less
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
 EndFPST
@@ -1789,10 +1789,10 @@ LangName: 1033 "" "" "" "DejaVu Sans Code Bold" "" "Version 2.37" "" "" "DejaVu 
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
-DisplaySize: -24
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 1114080 33 4
+WinInfo: 7821 33 4
 BeginPrivate: 0
 EndPrivate
 GridOrder2: 1
@@ -1917,7 +1917,7 @@ Grid
  0 1901 l 1,5,-1
 EndSplineSet
 AnchorClass2: "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" "above"  "'mark' Mark Positioning lookup 7" "below"  "'mark' Mark Positioning lookup 6" "rtl-above"  "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above"  "'mark' Mark Positioning in Arabic lookup 4" "rtl-below"  "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below"  "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark"  "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark"  "'mkmk' Mark to Mark in Arabic lookup 0" 
-BeginChars: 1114181 3733
+BeginChars: 1114181 3779
 
 StartChar: .notdef
 Encoding: 0 -1 0
@@ -29110,7 +29110,7 @@ EndChar
 StartChar: hookabovecomb
 Encoding: 777 777 664
 Width: 1233
-Flags: W
+Flags: WO
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
@@ -53448,9 +53448,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3669 -1 N 1 0 0 1 0 515 2
-Refer: 34 65 N 1 0 0 1 0 0 2
-Refer: 3674 -1 N 1 0 0 1 0 -128 2
+Refer: 3669 -1 N 1 0 0 1 -51 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni1EB1
@@ -53459,8 +53458,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 655 768 N 1 0 0 1 -49 466 2
 Refer: 195 259 N 1 0 0 1 0 0 3
-Refer: 655 768 N 1 0 0 1 0 316 2
 EndChar
 
 StartChar: uni1EB6
@@ -107689,6 +107688,466 @@ SplineSet
  3008 295 l 5,6,-1
 EndSplineSet
 Ligature2: "Programming ligatures lookup-1" less equal greater
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3733
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -7.49994 374.3 2
+Refer: 34 65 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3734
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3735
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 S 1 0 0 1 402 630 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3736
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 385 354 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3737
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3669 -1 S 1 0 0 1 -442 634.5 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3738
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -385 360 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3739
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 432 534.2 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3740
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 385 301 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3741
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 -1 759 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3742
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 453 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3743
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 N 1 0 0 1 49 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3744
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 N 1 0 0 1 49 466 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3745
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 16 664 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3746
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 399 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3747
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 0 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3748
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 421 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3749
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 21 378 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3750
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3751
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 S 1 0 0 1 409 640.5 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3752
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 436 360 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3753
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3669 -1 S 1 0 0 1 -375 621.5 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3754
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -358 360 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3755
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 424 584 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3756
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 385 280 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3757
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 30 759 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3758
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 39 453 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3759
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 357 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3760
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3761
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 372 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3762
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3763
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 S 1 0 0 1 390 615 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3764
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 361 367 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3765
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3669 -1 S 1 0 0 1 -410.5 636.4 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3766
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -367 373 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3767
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 427.5 578.1 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3768
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 350 287 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3769
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 -1 759 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3770
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 454 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3771
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -105 364 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3772
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -102 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3773
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -21 378 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3774
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -18 0 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3775
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -126 378 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3776
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -174 18 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3777
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -14 360 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3778
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont

--- a/src/DejaVuSansCode-BoldOblique.sfd
+++ b/src/DejaVuSansCode-BoldOblique.sfd
@@ -18,7 +18,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: 1470648524
-ModificationTime: 1505817247
+ModificationTime: 1557141727
 PfmFamily: 17
 TTFWeight: 700
 TTFWidth: 5
@@ -51,78 +51,78 @@ MarkAttachClasses: 1
 DEI: 91125
 ChainSub2: glyph "'calt' Programming contextual alternatives lookup 1"  0 0 0 15
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 5 equal
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 16 equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 22 equal_equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 4 plus
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 14 plus_plus.liga
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 14 plus_plus.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 4 plus
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 18 greater_equal.liga
  BString: 7 greater
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 15 less_equal.liga
  BString: 4 less
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
 EndFPST
@@ -1354,10 +1354,10 @@ LangName: 1033 "" "" "Bold Oblique" "DejaVu Sans Code Bold Oblique" "" "Version 
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
-DisplaySize: -24
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 1114047 33 4
+WinInfo: 7821 33 4
 BeginPrivate: 0
 EndPrivate
 GridOrder2: 1
@@ -1482,7 +1482,7 @@ Grid
  0 1901 l 1,5,-1
 EndSplineSet
 AnchorClass2: "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" 
-BeginChars: 1114154 3128
+BeginChars: 1114154 3174
 
 StartChar: .notdef
 Encoding: 0 -1 0
@@ -31913,7 +31913,7 @@ EndChar
 StartChar: hookabovecomb
 Encoding: 777 777 662
 Width: 1233
-Flags: W
+Flags: WO
 LayerCount: 2
 Fore
 SplineSet
@@ -51747,8 +51747,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 3093 -1 N 1 0 0 1 75.657 380 2
 Refer: 1573 7840 N 1 0 0 1 0 0 3
-Refer: 3093 -1 N 1 0 0 1 0 380 2
 EndChar
 
 StartChar: uni1EAD
@@ -51757,8 +51757,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 620 710 N 1 0 0 1 9.29753 9 2
 Refer: 1574 7841 N 1 0 0 1 0 0 3
-Refer: 620 710 N 1 0 0 1 -24.5 7 2
 EndChar
 
 StartChar: uni1EB0
@@ -51767,9 +51767,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3097 -1 N 1 0 0 1 0 -128 2
-Refer: 3092 -1 N 1 0 0 1 108 515 2
-Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 99.0377 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni1EB1
@@ -51778,7 +51777,7 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 653 768 N 1 0 0 1 66 316 2
+Refer: 653 768 N 1 0 0 1 41.9088 466 2
 Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
 
@@ -51848,8 +51847,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 3093 -1 N 1 0 0 1 96.657 380 2
 Refer: 1581 7864 N 1 0 0 1 0 0 3
-Refer: 3093 -1 N 1 0 0 1 23.5 380 2
 EndChar
 
 StartChar: uni1EC7
@@ -51858,8 +51857,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 620 710 N 1 0 0 1 2.90876 9 2
 Refer: 1582 7865 N 1 0 0 1 0 0 3
-Refer: 620 710 N 1 0 0 1 34.5 7 2
 EndChar
 
 StartChar: uni1ECA
@@ -52009,7 +52008,7 @@ Flags: W
 LayerCount: 2
 Fore
 Refer: 688 803 N 1 0 0 1 0 0 2
-Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni1EE5
@@ -52019,7 +52018,7 @@ Flags: W
 LayerCount: 2
 Fore
 Refer: 688 803 N 1 0 0 1 0 0 2
-Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni1EE8
@@ -52028,8 +52027,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 3089 -1 S 1 0 0 1 21.0064 430 2
 Refer: 367 431 N 1 0 0 1 0 0 3
-Refer: 3089 -1 N 1 0 0 1 -138 373 2
 EndChar
 
 StartChar: uni1EE9
@@ -52048,8 +52047,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 3092 -1 S 1 0 0 1 -57.4935 415 2
 Refer: 367 431 N 1 0 0 1 0 0 3
-Refer: 3092 -1 N 1 0 0 1 -138 373 2
 EndChar
 
 StartChar: uni1EEB
@@ -52068,8 +52067,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 3090 -1 S 1 0 0 1 -30.141 420 2
 Refer: 367 431 N 1 0 0 1 0 0 3
-Refer: 3090 -1 N 1 0 0 1 -138 373 2
 EndChar
 
 StartChar: uni1EEF
@@ -87663,6 +87662,466 @@ SplineSet
  3008 295 l 5,6,-1
 EndSplineSet
 Ligature2: "Programming ligatures lookup-1" less equal greater
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3128
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 203 360.3 2
+Refer: 34 65 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3129
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 156 6 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3130
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 498.409 627 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3131
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 S 1 0 0 1 452.909 360 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3132
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3092 -1 S 1 0 0 1 -314.091 627 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3133
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 768 S 1 0 0 1 -250.591 378 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3134
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 648 536 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3135
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 581 292 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3136
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 117.261 759 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3137
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 119.705 453 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3138
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 N 1 0 0 1 197.538 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3139
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 N 1 0 0 1 139.409 466 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3140
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 256 696 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3141
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 231 441 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3142
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 146.39 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3143
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 82.2052 421 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3144
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 210 343 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3145
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 156 -6 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3146
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 547.409 621 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3147
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 S 1 0 0 1 421.909 354 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3148
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3092 -1 S 1 0 0 1 -265.091 616.5 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3149
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 768 S 1 0 0 1 -299.591 371 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3150
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 664 560 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3151
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 567 266 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3152
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 154.261 759 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3153
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 88.7052 453 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3154
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 203 346.3 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3155
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 162 0 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3156
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 189 385 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3157
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 156 18 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3158
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 498.409 633 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3159
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 S 1 0 0 1 427.909 354 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3160
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3092 -1 S 1 0 0 1 -296.091 633 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3161
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 768 S 1 0 0 1 -287.591 378 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3162
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 616 585.665 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3163
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 557.815 306 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3164
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 117.261 759 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3165
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 88.7052 453 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3166
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 119 364 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3167
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 46 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3168
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 190 357.2 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3169
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 144 0 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3170
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 112 378 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3171
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 0 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3172
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 175 385 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3173
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 147 0 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont

--- a/src/DejaVuSansCode-Oblique.sfd
+++ b/src/DejaVuSansCode-Oblique.sfd
@@ -18,7 +18,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: 1470648549
-ModificationTime: 1505817115
+ModificationTime: 1557140300
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -51,78 +51,78 @@ MarkAttachClasses: 1
 DEI: 91125
 ChainSub2: glyph "'calt' Programming contextual alternatives lookup 1"  0 0 0 15
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 5 equal
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 16 equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 22 equal_equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 4 plus
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 14 plus_plus.liga
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 14 plus_plus.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 4 plus
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 18 greater_equal.liga
  BString: 7 greater
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 15 less_equal.liga
  BString: 4 less
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
 EndFPST
@@ -1772,10 +1772,10 @@ LangName: 1033 "" "" "" "DejaVu Sans Code Oblique" "" "Version 2.37" "" "" "Deja
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
-DisplaySize: -24
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 1114047 33 4
+WinInfo: 7788 33 7
 BeginPrivate: 0
 EndPrivate
 GridOrder2: 1
@@ -1900,7 +1900,7 @@ Grid
  0 1901 l 1,5,-1
 EndSplineSet
 AnchorClass2: "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" 
-BeginChars: 1114153 3127
+BeginChars: 1114153 3173
 
 StartChar: .notdef
 Encoding: 0 -1 0
@@ -31235,7 +31235,7 @@ EndChar
 StartChar: hookabovecomb
 Encoding: 777 777 661
 Width: 1233
-Flags: W
+Flags: WO
 LayerCount: 2
 Fore
 SplineSet
@@ -50610,9 +50610,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3091 -1 N 1 0 0 1 84.4999 515 2
-Refer: 34 65 N 1 0 0 1 0 0 2
-Refer: 3096 -1 N 1 0 0 1 0 -128 2
+Refer: 3091 -1 N 1 0 0 1 106.427 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni1EB1
@@ -50621,8 +50620,8 @@ Width: 1233
 Flags: W
 LayerCount: 2
 Fore
+Refer: 652 768 N 1 0 0 1 32.4088 468 2
 Refer: 195 259 N 1 0 0 1 0 0 3
-Refer: 652 768 N 1 0 0 1 0 316 2
 EndChar
 
 StartChar: uni1EB6
@@ -87433,6 +87432,466 @@ SplineSet
  3131 352 l 5,6,-1
 EndSplineSet
 Ligature2: "Programming ligatures lookup-1" less equal greater
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3127
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 229 355 2
+Refer: 34 65 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3128
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 204 6 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3129
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 413.409 642.7 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3130
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 S 1 0 0 1 381.409 366 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3131
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3091 -1 S 1 0 0 1 -213.091 642.7 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3132
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 652 768 S 1 0 0 1 -228.091 384 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3133
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 576.302 546.324 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3134
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 490 245 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3135
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 107.193 729 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3136
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 90.7052 453 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3137
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 N 1 0 0 1 210.927 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3138
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 N 1 0 0 1 155.909 468 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3139
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 272 672 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3140
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 372.924 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3141
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 138.712 729 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3142
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 81.2052 423 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3143
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 273 353.224 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3144
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 204 0 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3145
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 488.409 635 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3146
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 S 1 0 0 1 389.409 372 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3147
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3091 -1 S 1 0 0 1 -174.091 635 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3148
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 652 768 S 1 0 0 1 -250.091 372 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3149
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 592 568 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3150
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 518 298.924 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3151
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 152.193 729 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3152
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 86.7052 453 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3153
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 217 371 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3154
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 186 0 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3155
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 238 378 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3156
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 198 12 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3157
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 423.409 623 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3158
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 S 1 0 0 1 365.409 366 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3159
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3091 -1 S 1 0 0 1 -239.091 641 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3160
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 652 768 S 1 0 0 1 -226.091 372 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3161
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 552 577.526 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3162
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 497 291.924 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3163
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 99.1934 729 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3164
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 86.7052 453 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3165
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 126 357 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3166
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 78 12 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3167
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 203 371 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3168
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 162 -18 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3169
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 63 336 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3170
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 0 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3171
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 203 343 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3172
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 147 0 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont

--- a/src/DejaVuSansCode.sfd
+++ b/src/DejaVuSansCode.sfd
@@ -18,7 +18,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: 1470648488
-ModificationTime: 1505816752
+ModificationTime: 1557140016
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -67,78 +67,78 @@ MarkAttachClasses: 1
 DEI: 91125
 ChainSub2: glyph "'calt' Programming contextual alternatives lookup 1"  0 0 0 15
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 5 equal
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 16 equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
- BString: 0
+ BString: 0 
  FString: 22 equal_equal_equal.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 5 equal
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 11 slash slash
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 16 equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 22 equal_equal_equal.liga
  BString: 10 numbersign
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 4 plus
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 14 plus_plus.liga
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
- BString: 0
+ BString: 0 
  FString: 14 plus_plus.liga
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 14 plus_plus.liga
  BString: 4 plus
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 18 greater_equal.liga
  BString: 7 greater
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
  String: 15 less_equal.liga
  BString: 4 less
- FString: 0
+ FString: 0 
  1
   SeqLookup: 0 "'ccmp' Programming glyphs decomposition lookup" 
 EndFPST
@@ -2385,10 +2385,10 @@ LangName: 1033 "" "" "" "DejaVu Sans Code" "" "Version 2.37" "" "" "DejaVu fonts
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
-DisplaySize: -24
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 1114080 33 4
+WinInfo: 7800 20 7
 BeginPrivate: 0
 EndPrivate
 GridOrder2: 1
@@ -2513,7 +2513,7 @@ Grid
  0 1901 l 1,5,-1
 EndSplineSet
 AnchorClass2: "cedilla"  "'mark' cedilla" "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" "above"  "'mark' above, below" "below"  "'mark' above, below" "rtl-above"  "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above"  "'mark' Mark Positioning in Arabic lookup 4" "rtl-below"  "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below"  "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark"  "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark"  "'mkmk' Mark to Mark in Arabic lookup 0" 
-BeginChars: 1114181 3794
+BeginChars: 1114181 3840
 
 StartChar: .notdef
 Encoding: 0 -1 0
@@ -55635,9 +55635,8 @@ Encoding: 7856 7856 1678
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 3735 -1 N 1 0 0 1 0 -128 2
-Refer: 34 65 N 1 0 0 1 0 0 2
-Refer: 3730 -1 N 1 0 0 1 0 515 2
+Refer: 3730 -1 N 1 0 0 1 -64.5 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
 
 StartChar: uni1EB1
@@ -55645,7 +55644,7 @@ Encoding: 7857 7857 1679
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 655 768 N 1 0 0 1 0 316 2
+Refer: 655 768 N 1 0 0 1 -64.5 468 2
 Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
 
@@ -110341,6 +110340,467 @@ SplineSet
 EndSplineSet
 LCarets2: 2 0 0 
 Ligature2: "Programming ligatures lookup-1" less equal greater
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3794
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 353 2
+Refer: 34 65 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3795
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3796
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 S 1 0 0 1 376.5 648 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3797
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 352.5 341.8 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3798
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3730 -1 S 1 0 0 1 -376.5 648 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3799
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -334.5 366 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3800
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 381 583 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3801
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 348 345 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3802
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 0 729 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3803
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 451 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3804
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 N 1 0 0 1 64.5 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3805
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 N 1 0 0 1 64.5 468 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3806
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 635 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3807
+Width: 1233
+VWidth: 0
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 342 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3808
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 0 729 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3809
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 421 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3810
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 378 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3811
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3812
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 S 1 0 0 1 364.5 623 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3813
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 306.5 366 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3814
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3730 -1 S 1 0 0 1 -358.5 629 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3815
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -278.5 360 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3816
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 384 572.824 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3817
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 343 301 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3818
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 18 729 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3819
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 14 451 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3820
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 21.4999 374.224 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3821
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3822
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 385 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3823
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3824
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 S 1 0 0 1 364.5 626.6 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3825
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 304.5 354 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3826
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3730 -1 S 1 0 0 1 -376.5 605 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3827
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -316.5 342 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3828
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 392 592 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3829
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 371 280 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3830
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 0 729 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3831
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 451 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3832
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -126 343.909 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3833
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -114 18 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3834
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 12 379 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3835
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3836
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -140 343 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3837
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -162 -12 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3838
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 322 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3839
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 12 36 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
Vietnamese language support has long been a big flaw in the DejaVu Sans Mono family. I created a PR request in the base DejaVu Fonts repository, but I've got no response since then.

In this PR, I add missing glyphs in `U+1EA0` – `U+1EF9` range. This should complete the Vietnamese language cover (when `langcover.txt` is updated). If not, please let me know, I'll find missing glyphs to add them.
